### PR TITLE
Size limited, rubocop happy

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,2 +1,41 @@
-inherit_gem:
-bixby: bixby_default.yml
+require: rubocop-rspec
+
+LineLength:
+  Max: 120
+
+# See https://github.com/rubocop-hq/rubocop/issues/6410
+Layout/AlignHash:
+  Enabled: false
+
+# Add security checks so Codacy can confirm them
+Security:
+  Enabled: true
+
+Rails/OutputSafety:
+  Enabled: true
+
+Style/MutableConstant:
+  Enabled: true
+
+Metrics/BlockLength:
+  Exclude:
+    - Rakefile
+    - '**/*.rake'
+    - spec/**/*.rb
+
+Layout/MultilineMethodCallIndentation:
+  EnforcedStyle: indented
+
+Layout/MultilineOperationIndentation:
+  EnforcedStyle: indented
+
+RSpec/ExampleLength:
+  Max: 30
+
+RSpec/DescribeClass:
+  Exclude:
+    - 'spec/*'
+
+RSpec/NestedGroups:
+  Exclude:
+    - 'spec/*'

--- a/lib/delegates.rb
+++ b/lib/delegates.rb
@@ -75,7 +75,24 @@ class CustomDelegate
   # @return [Boolean] Whether the request is authorized.
   #
   def authorized?(_options = {})
-    true
+    logger = Java::edu.illinois.library.cantaloupe.script.Logger
+    permitted = true
+
+    full_width = context['full_size']['width'].to_f
+    request = context['request_uri'].split('/')
+    region = request[request.length - 4]
+    requested_size = request[request.length - 3]
+    requested_width = requested_size.split(',')[0]
+
+    # A temporary and simplistic (i.e. not foolproof) size restriction
+    if ((region == 'full' && (requested_width == 'full' || requested_width == 'max')) ||
+        requested_width.to_i > (full_width * 0.5).to_i) then
+      # Don't allow image requests that are more than 50% of the original
+      permitted = false
+    end
+
+    logger.debug 'Authorization is granted: ' + permitted.to_s
+    permitted
   end
 
   ##

--- a/spec/custom_delegate_spec.rb
+++ b/spec/custom_delegate_spec.rb
@@ -9,4 +9,18 @@ describe CustomDelegate do
     image_url = 'http://localhost:8984/fcrepo/rest/prod/4x/51/hj/00/' + id
     expect(delegate.httpsource_resource_info).to eq(image_url)
   end
+
+  it 'authenticates iiif full request' do
+    uri = 'http://example.org/iiif/asdfasdf/full/full/0/default.jpg'
+    delegate = described_class.new
+    delegate.context = { 'request_uri' => uri, 'client_ip' => '127.0.0.1' }
+    expect(delegate.authorized?).to be(false)
+  end
+
+  it 'authenticates iiif simple request' do
+    uri = 'http://example.org/iiif/asdfasdf/125,15,120,140/full/0/default.jpg'
+    delegate = described_class.new
+    delegate.context = { 'request_uri' => uri, 'full_size' => { 'width' => '1024', 'height' => '1024' } }
+    expect(delegate.authorized?).to be(true)
+  end
 end


### PR DESCRIPTION
* Used the rubocop config we're using on docker-cantaloupe
* Cleaned up code from the `size-limited` branch that worked but that made rubocop unhappy
* Added two tests