### PR TITLE
allow filesystem source

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,10 @@ dist: trusty
 language: ruby
 cache: bundler
 sudo: false
-script:
+install:
+  - jruby -S gem install bundler -v 2.0.1
   - jruby -S bundle install
+script:
   - jruby -S bundle exec rake
 jdk:
   - oraclejdk8


### PR DESCRIPTION
chooses a source based on the identifier: if it starts with "Masters/", then use the FilesystemSource. Otherwise, use HttpSource as before to retreive from fedora.

(the slash must be url-escaped as %2F in the request, but it is already unescaped by the time the delegate script is invoked)

Also adds the method `authorize`, which replaces `authorized?` and `redirect` in Cantaloupe 4.1 (https://cantaloupe-project.github.io/manual/4.1/delegate-script.html#MigratingFrom4To41)