### PR TITLE
[IIIF-526] Make SinaiPoC cookie friendly

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,9 +11,6 @@ Layout/AlignHash:
 Security:
   Enabled: true
 
-Rails/OutputSafety:
-  Enabled: true
-
 Style/MutableConstant:
   Enabled: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,6 @@ jdk:
   - oraclejdk8
 rvm:
   - jruby
+branches:
+  only:
+  - master

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 gem 'bixby', '~> 1.0' # bixby == the samvera community's rubocop rules
 gem 'rake'

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,4 @@
-ENV['FEDORA_URL'] = 'http://localhost:8984/fcrepo/rest'
-ENV['FEDORA_BASE_PATH'] = '/prod'
+# frozen_string_literal: true
 
 require 'rake'
 require 'rspec/core/rake_task'


### PR DESCRIPTION
This PR depends on https://github.com/UCLALibrary/sinaipoc/pull/25 (to run against the server; it runs on its own as is, of course).

This PR updates the Cantaloupe delegate to read the value of the cookie that's set in the above PR. For this PR to work, there need to be some ENV properties set on the Cantaloupe side:

CIPHER_TEXT=Authenticated
CIPHER_KEY=ThisPasswordIsReallyHardToGuess!

These will all be changed when we actually do something with this code.