### PR TITLE
IIIF-526 Fix cookie parsing

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,6 @@
 require: rubocop-rspec
 
-LineLength:
+Metrics/LineLength:
   Max: 120
 
 # See https://github.com/rubocop-hq/rubocop/issues/6410

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -36,3 +36,6 @@ RSpec/DescribeClass:
 RSpec/NestedGroups:
   Exclude:
     - 'spec/*'
+
+AllCops:
+  TargetRubyVersion: 2.5

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # cantaloupe-delegate &nbsp;[![Build Status](https://travis-ci.org/UCLALibrary/cantaloupe-delegate.svg?branch=master)](https://travis-ci.org/UCLALibrary/cantaloupe-delegate)
 
-A delegate script for the Cantaloupe IIIF server that takes a Hyrax file ID returns a Fedora URL.
+A delegate script for the Cantaloupe IIIF server that serves images from an S3 bucket.
 
 ### Running tests
 

--- a/README.md
+++ b/README.md
@@ -16,9 +16,26 @@ If you install JRuby in another way, you may need to run the following commands 
 
 ### Running Cantaloupe
 
-While not needed to run the test, to start Cantaloupe with the required delegate environmental variables:
+While not needed to run the tests (those are self-contained), to start UCLA's [Cantaloupe container](https://cloud.docker.com/u/uclalibrary/repository/docker/uclalibrary/cantaloupe) with the required delegate environmental variables:
 
-    FEDORA_URL="http://localhost:8984/fcrepo/rest" \
-      FEDORA_BASE_PATH="/prod" \
-      java -Dcantaloupe.config=cantaloupe.properties \
-      -Xmx2g -jar cantaloupe-4.0.2.war
+    docker run -d -p 8182:8182 \
+      -e "CANTALOUPE_ENDPOINT_ADMIN_SECRET=secret" \
+      -e "CANTALOUPE_ENDPOINT_ADMIN_ENABLED=true" \
+      -e "CANTALOUPE_DELEGATE_SCRIPT_ENABLED=true" \
+      -e "CANTALOUPE_DELEGATE_SCRIPT_PATHNAME=/usr/local/cantaloupe/delegates.rb" \
+      -e "CANTALOUPE_DELEGATE_SCRIPT_CACHE_ENABLED=false" \
+      -e "CANTALOUPE_SOURCE_DELEGATE=true" \
+      -e "CANTALOUPE_S3SOURCE_LOOKUP_STRATEGY=BasicLookupStrategy" \
+      -e "CANTALOUPE_S3SOURCE_BASICLOOKUPSTRATEGY_PATH_SUFFIX=.jpg" \
+      -e "CANTALOUPE_S3SOURCE_BASICLOOKUPSTRATEGY_BUCKET_NAME=YOUR_BUCKET_NAME" \
+      -e "CANTALOUPE_S3SOURCE_SECRET_KEY=YOUR_SECRET_KEY" \
+      -e "CANTALOUPE_S3SOURCE_ACCESS_KEY_ID=YOUR_ACCESS_KEY" \
+      -e "CANTALOUPE_S3SOURCE_ENDPOINT=s3.amazonaws.com" \
+      -e "CANTALOUPE_LOG_APPLICATION_FILEAPPENDER_ENABLED=true" \
+      -e "CIPHER_TEXT=Authenticated" \
+      -e "CIPHER_KEY=ThisPasswordIsReallyHardToGuess!" \
+      -e "CANTALOUPE_LOG_APPLICATION_FILEAPPENDER_PATHNAME=/var/log/cantaloupe/cantaloupe.log" \
+      -e "DELEGATE_URL=https://raw.githubusercontent.com/UCLALibrary/cantaloupe-delegate/master/lib/delegates.rb" \
+      --name melon -v /sinai:/imageroot uclalibrary/cantaloupe:4.1.4
+
+The above configuration would be used to configure an S3 backend. A different configuration could be used to configure a file system backend.

--- a/lib/delegates.rb
+++ b/lib/delegates.rb
@@ -99,9 +99,7 @@ class CustomDelegate
   # @return [Boolean,Hash<String,Object>] See above.
   #
   def authorize(_options = {})
-    # Fun, fun... our Cantaloupe docker container likes it one way, our dev machines another
     @cookies = context['cookies']
-    @cookies = context[:cookies] if @cookies.nil?
 
     # Our important cookie names
     iv = 'initialization_vector'

--- a/lib/delegates.rb
+++ b/lib/delegates.rb
@@ -105,12 +105,28 @@ class CustomDelegate
     iv = 'initialization_vector'
     auth = 'sinai_authenticated'
 
+    # If we have just the raw cookies header, parse it into cookies
+    parse_cookies if @cookies&.key?('Cookie')
+
     # Check whether we're authorized to view the requested item
     if image_request?
-      @cookies.key?(iv) && @cookies.key?(auth) && auth_value.start_with?(ENV['CIPHER_TEXT'])
+      @cookies&.key?(iv) && @cookies&.key?(auth) && auth_value.start_with?(ENV['CIPHER_TEXT'])
     else
       true
     end
+  end
+
+  # If we don't have nicely parsed cookies in our context, parse them ourselves
+  def parse_cookies
+    cookie_hash = {}
+    raw_value = @cookies['Cookie']
+    values = raw_value.split(';')
+    values.each do |item|
+      item.strip! if item.respond_to? :strip!
+      parts = item.split('=')
+      cookie_hash[parts[0]] = parts[1]
+    end
+    @cookies = cookie_hash
   end
 
   # Check whether a request is an image or info.json request

--- a/lib/delegates.rb
+++ b/lib/delegates.rb
@@ -102,15 +102,15 @@ class CustomDelegate
     @cookies = context['cookies']
 
     # Our important cookie names
-    iv = 'initialization_vector'
-    auth = 'sinai_authenticated'
+    @iv = 'initialization_vector'
+    @auth = 'sinai_authenticated'
 
     # If we have just the raw cookies header, parse it into cookies
     parse_cookies if @cookies&.key?('Cookie')
 
     # Check whether we're authorized to view the requested item
     if image_request?
-      @cookies&.key?(iv) && @cookies&.key?(auth) && auth_value.start_with?(ENV['CIPHER_TEXT'])
+      @cookies&.key?(@iv) && @cookies&.key?(@auth) && auth_value.start_with?(ENV['CIPHER_TEXT'])
     else
       true
     end
@@ -136,10 +136,10 @@ class CustomDelegate
 
   # Check the authentication value in the expected auth cookie
   def auth_value
-    cipher_text = @cookies['sinai_authenticated']
+    cipher_text = @cookies[@auth]
     decipher = OpenSSL::Cipher::AES256.new :CBC
     decipher.decrypt
-    decipher.iv = @cookies['initialization_vector']
+    decipher.iv = @cookies[@iv]
     decipher.key = ENV['CIPHER_KEY']
     auth_cookie = [cipher_text].pack('H*').unpack('C*').pack('c*')
     decipher.update(auth_cookie) + decipher.final

--- a/spec/custom_delegate_spec.rb
+++ b/spec/custom_delegate_spec.rb
@@ -16,6 +16,7 @@ describe CustomDelegate do
   cipher_text = cipher.update(ENV['CIPHER_TEXT'] + ' random stuff') + cipher.final
   auth_cookie_value = cipher_text.unpack('H*')[0].upcase
 
+  puts auth_cookie_value
   # Now the testing begins...
 
   it 'passes if the requested item is an info.json file' do
@@ -32,7 +33,7 @@ describe CustomDelegate do
     delegate.context = {
       'request_uri' => 'http://example.org/iiif/asdfasdf/full/pct:70/0/default.jpg',
       'full_size' => { 'width' => '1024', 'height' => '1024' },
-      :cookies => { 'nope' => 0 }
+      'cookies' => { 'nope' => 0 }
     }
     expect(delegate.authorize).to eq(false)
   end
@@ -42,21 +43,34 @@ describe CustomDelegate do
     delegate.context = {
       'request_uri' => 'http://example.org/iiif/asdfasdf/full/pct:70/0/default.jpg',
       'full_size' => { 'width' => '1024', 'height' => '1024' },
-      :cookies => {
+      'cookies' => {
         'sinai_authenticated' => auth_cookie_value
       }
     }
     expect(delegate.authorize).to eq(false)
   end
 
-  it 'passes if we send the necessary cookies with acceptible values' do
+  it 'passes if we send the necessary computed cookies with acceptable values' do
     delegate = described_class.new
     delegate.context = {
       'request_uri' => 'http://example.org/iiif/asdfasdf/full/pct:70/0/default.jpg',
       'full_size' => { 'width' => '1024', 'height' => '1024' },
-      :cookies => {
+      'cookies' => {
         'initialization_vector' => iv,
         'sinai_authenticated' => auth_cookie_value
+      }
+    }
+    expect(delegate.authorize).to be(true)
+  end
+
+  it 'passes if we send the necessary cookies with acceptable values' do
+    delegate = described_class.new
+    delegate.context = {
+      'request_uri' => 'http://example.org/iiif/asdfasdf/full/pct:70/0/default.jpg',
+      'full_size' => { 'width' => '1024', 'height' => '1024' },
+      'cookies' => {
+        'initialization_vector' => iv,
+        'sinai_authenticated' => 'D4B197B706847D941E2232E7882258B2A71EC589A02A8F957AD5BAEBECB0528E'
       }
     }
     expect(delegate.authorize).to be(true)
@@ -67,7 +81,7 @@ describe CustomDelegate do
     delegate.context = {
       'request_uri' => 'http://example.org/iiif/asdfasdf/full/pct:70/0/default.jpg',
       'full_size' => { 'width' => '1024', 'height' => '1024' },
-      :cookies => {
+      'cookies' => {
         'initialization_vector' => iv,
         'sinai_authenticated' => auth_cookie_value
       }

--- a/spec/custom_delegate_spec.rb
+++ b/spec/custom_delegate_spec.rb
@@ -14,7 +14,7 @@ describe CustomDelegate do
   cipher.key = ENV['CIPHER_KEY']
   cipher.iv = iv
   cipher_text = cipher.update(ENV['CIPHER_TEXT'] + ' random stuff') + cipher.final
-  auth_cookie_value = cipher_text.unpack('H*')[0].upcase
+  auth_cookie_value = cipher_text.unpack1('H*').upcase
 
   # Now the testing begins...
 

--- a/spec/custom_delegate_spec.rb
+++ b/spec/custom_delegate_spec.rb
@@ -76,6 +76,20 @@ describe CustomDelegate do
     expect(delegate.authorize).to be(true)
   end
 
+  it 'passes if we send the raw cookie string with acceptable values' do
+    delegate = described_class.new
+    delegate.context = {
+      'request_uri' => 'http://example.org/iiif/asdfasdf/full/pct:70/0/default.jpg',
+      'full_size' => { 'width' => '1024', 'height' => '1024' },
+      'cookies' =>
+        {
+          'Cookie' => 'initialization_vector=abcdefghijklmnop; ' \
+            'sinai_authenticated=D4B197B706847D941E2232E7882258B2A71EC589A02A8F957AD5BAEBECB0528E'
+        }
+    }
+    expect(delegate.authorize).to be(true)
+  end
+
   it 'passes if delegate source is set to S3Source' do
     delegate = described_class.new
     delegate.context = {

--- a/spec/custom_delegate_spec.rb
+++ b/spec/custom_delegate_spec.rb
@@ -16,7 +16,6 @@ describe CustomDelegate do
   cipher_text = cipher.update(ENV['CIPHER_TEXT'] + ' random stuff') + cipher.final
   auth_cookie_value = cipher_text.unpack('H*')[0].upcase
 
-  puts auth_cookie_value
   # Now the testing begins...
 
   it 'passes if the requested item is an info.json file' do


### PR DESCRIPTION
* Add S3Source
* Add cookie parsing when Cantaloupe delivers them unparsed
* Update Rubocop rules
* Update README with sample of how to run/test locally

Our tests expected Cantaloupe to deliver cookies like the documentation says it will, but it seems to be passing an unparsed Cookie header instead so we add a little code to parse the cookies into the expected Hash.