### PR TITLE
[IIIF-534] Update delegate to read unpacked IV

### DIFF
--- a/lib/delegates.rb
+++ b/lib/delegates.rb
@@ -136,12 +136,12 @@ class CustomDelegate
 
   # Check the authentication value in the expected auth cookie
   def auth_value
-    cipher_text = @cookies[@auth]
     decipher = OpenSSL::Cipher::AES256.new :CBC
     decipher.decrypt
-    decipher.iv = @cookies[@iv]
+    iv_cookie = [@cookies[@iv]].pack('H*').unpack('C*').pack('c*')
+    decipher.iv = iv_cookie
     decipher.key = ENV['CIPHER_KEY']
-    auth_cookie = [cipher_text].pack('H*').unpack('C*').pack('c*')
+    auth_cookie = [@cookies[@auth]].pack('H*').unpack('C*').pack('c*')
     decipher.update(auth_cookie) + decipher.final
   end
 


### PR DESCRIPTION
Apps team is going to unpack the IV (and use a random value for it), so we need to pack it again on our side (in the delegate) before we use it to decrypt the encrypted string.

Tests updated to use a random IV and one test was removed because it just becomes a duplicate of one of the other existing tests once we start using a random IV.

Got rid of the cipher_text variable to make rubocop's checks happy (too many assigned variables, it said).