### PR TITLE
Allow preconfigured IPs through load balanced auth check

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,11 @@ While not needed to run the tests (those are self-contained), to start UCLA's [C
       --name melon -v /sinai:/imageroot uclalibrary/cantaloupe:4.1.4
 
 The above configuration would be used to configure an S3 backend. A different configuration could be used to configure a file system backend.
+
+### Assumptions about IP access
+
+This version of the delegate assumes Cantaloupe is running behind the Amazon Load Balancer (ALB). This is because it relies on the 'X-Forwarded-For header' for authentication, which is easy to spoof if access to Cantaloupe isn't restricted to ALB connections. If not running behind the ALB, the IP check code in this delegate should be removed.
+
+### Contact
+
+Feel free to send any questions, suggestions, or bug reports to this project's [issues queue](https://github.com/UCLALibrary/cantaloupe-delegate/issues).

--- a/lib/delegates.rb
+++ b/lib/delegates.rb
@@ -118,13 +118,17 @@ class CustomDelegate
   end
 
   def ip_okay?
-    ips = Set.new
+    headers = context['request_headers']
+    xforwardedfor = headers['X-Forwarded-For'] if headers
 
+    return unless xforwardedfor
+
+    ip = xforwardedfor.split(',').map(&:strip).last
+    ips = Set.new
     ips << '52.32.59.248'
     ips << '54.201.202.237'
     ips << '47.134.162.230'
-
-    ips.include?(context['client_ip'])
+    ips.include?(ip)
   end
 
   # If we don't have nicely parsed cookies in our context, parse them ourselves

--- a/lib/delegates.rb
+++ b/lib/delegates.rb
@@ -18,6 +18,7 @@
 
 require 'openssl'
 require 'cgi'
+require 'set'
 
 # Cantaloupe CustomDelegate method for customized authentication, and more!
 class CustomDelegate
@@ -110,10 +111,20 @@ class CustomDelegate
 
     # Check whether we're authorized to view the requested item
     if image_request?
-      @cookies&.key?(@iv) && @cookies&.key?(@auth) && auth_value.start_with?(ENV['CIPHER_TEXT'])
+      ip_okay? | (@cookies&.key?(@iv) && @cookies&.key?(@auth) && auth_value.start_with?(ENV['CIPHER_TEXT']))
     else
       true
     end
+  end
+
+  def ip_okay?
+    ips = Set.new
+
+    ips << '52.32.59.248'
+    ips << '54.201.202.237'
+    ips << '47.134.162.230'
+
+    ips.include?(context['client_ip'])
   end
 
   # If we don't have nicely parsed cookies in our context, parse them ourselves

--- a/spec/custom_delegate_spec.rb
+++ b/spec/custom_delegate_spec.rb
@@ -28,22 +28,46 @@ describe CustomDelegate do
     expect(delegate.authorize).to eq(true)
   end
 
-  it 'passes if the request is coming from a known IP address' do
+  # The assumption here is that ALB is setting the header and cantaloupe can't be accessed directly
+  it 'passes if the only IP in X-Forwarded-For is an expected one' do
     delegate = described_class.new
     delegate.context = {
       'request_uri' => 'http://example.org/iiif/asdfasdf/full/pct:70/0/default.jpg',
       'full_size' => { 'width' => '1024', 'height' => '1024' },
-      'client_ip' => '52.32.59.248'
+      'request_headers' => { 'X-Forwarded-For' => '52.32.59.248' }
     }
     expect(delegate.authorize).to eq(true)
   end
 
-  it 'fails to authenticate if the request is coming from an unknown IP address' do
+  # The assumption here is that ALB is setting the header and cantaloupe can't be accessed directly
+  it 'passes if the first IP in X-Forwarded-For is an expected one' do
     delegate = described_class.new
     delegate.context = {
       'request_uri' => 'http://example.org/iiif/asdfasdf/full/pct:70/0/default.jpg',
       'full_size' => { 'width' => '1024', 'height' => '1024' },
-      'client_ip' => '52.32.59.249'
+      'request_headers' => { 'X-Forwarded-For' => '52.32.59.249, 52.32.59.248' }
+    }
+    expect(delegate.authorize).to eq(true)
+  end
+
+  # The assumption here is that ALB is setting the header and cantaloupe can't be accessed directly
+  it 'fails if the only IP in X-Forwarded-For is not an expected one' do
+    delegate = described_class.new
+    delegate.context = {
+      'request_uri' => 'http://example.org/iiif/asdfasdf/full/pct:70/0/default.jpg',
+      'full_size' => { 'width' => '1024', 'height' => '1024' },
+      'request_headers' => { 'X-Forwarded-For' => '52.32.59.249' }
+    }
+    expect(delegate.authorize).to eq(false)
+  end
+
+  # The assumption here is that ALB is setting the header and cantaloupe can't be accessed directly
+  it 'fails if the first IP in X-Forwarded-For is not an expected one' do
+    delegate = described_class.new
+    delegate.context = {
+      'request_uri' => 'http://example.org/iiif/asdfasdf/full/pct:70/0/default.jpg',
+      'full_size' => { 'width' => '1024', 'height' => '1024' },
+      'request_headers' => { 'X-Forwarded-For' => '52.32.59.248, 52.32.59.249' }
     }
     expect(delegate.authorize).to eq(false)
   end

--- a/spec/custom_delegate_spec.rb
+++ b/spec/custom_delegate_spec.rb
@@ -28,6 +28,26 @@ describe CustomDelegate do
     expect(delegate.authorize).to eq(true)
   end
 
+  it 'passes if the request is coming from a known IP address' do
+    delegate = described_class.new
+    delegate.context = {
+      'request_uri' => 'http://example.org/iiif/asdfasdf/full/pct:70/0/default.jpg',
+      'full_size' => { 'width' => '1024', 'height' => '1024' },
+      'client_ip' => '52.32.59.248'
+    }
+    expect(delegate.authorize).to eq(true)
+  end
+
+  it 'fails to authenticate if the request is coming from an unknown IP address' do
+    delegate = described_class.new
+    delegate.context = {
+      'request_uri' => 'http://example.org/iiif/asdfasdf/full/pct:70/0/default.jpg',
+      'full_size' => { 'width' => '1024', 'height' => '1024' },
+      'client_ip' => '52.32.59.249'
+    }
+    expect(delegate.authorize).to eq(false)
+  end
+
   it 'fails to authenticate if only an irrelevant cookie is passed' do
     delegate = described_class.new
     delegate.context = {


### PR DESCRIPTION
Perform an IP check and let things from particular IPs go through without the cookie check.